### PR TITLE
Change location of configuration files, and other minor tweaks

### DIFF
--- a/info.portfolio_performance.PortfolioPerformance.appdata.xml
+++ b/info.portfolio_performance.PortfolioPerformance.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>info.portfolio_performance.PortfolioPerformance</id>
-  <name>PortfolioPerformance</name>
+  <name>Portfolio Performance</name>
   <summary>An open source tool to calculate the overall performance of an investment portfolio.</summary>
   <url type="homepage">https://www.portfolio-performance.info/en/</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/info.portfolio_performance.PortfolioPerformance.appdata.xml
+++ b/info.portfolio_performance.PortfolioPerformance.appdata.xml
@@ -34,8 +34,7 @@
 
   <url type="help">https://forum.portfolio-performance.info/</url>
 
-  <!--FIXME: where to submit translations-->
-  <url type="translate"><!-- http://www.homepage.com/how-to-submit-translations.html --></url>
+  <url type="translate">https://poeditor.com/join/project?hash=4lYKLpEWOY</url>
 
   <!--FIXME: this is optional, but recommended-->
   <update_contact><!-- upstream-contact_at_email.com --></update_contact>

--- a/info.portfolio_performance.PortfolioPerformance.desktop
+++ b/info.portfolio_performance.PortfolioPerformance.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Type=Application
-Comment=A simple tool to calculate the overall performance of an investment portfolio.
 Name=Portfolio Performance
+Comment=Calculate the overall performance of an investment portfolio
 Exec=PortfolioPerformance %f
 Icon=info.portfolio_performance.PortfolioPerformance
 Terminal=false
-Categories=Office
+Categories=Office;Finance;Java;

--- a/info.portfolio_performance.PortfolioPerformance.desktop
+++ b/info.portfolio_performance.PortfolioPerformance.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
-Name=PortfolioPerformance
 Comment=A simple tool to calculate the overall performance of an investment portfolio.
+Name=Portfolio Performance
 Exec=PortfolioPerformance %f
 Icon=info.portfolio_performance.PortfolioPerformance
 Terminal=false

--- a/info.portfolio_performance.PortfolioPerformance.json
+++ b/info.portfolio_performance.PortfolioPerformance.json
@@ -39,6 +39,7 @@
         "rm -rf icons",
         "install -Dm644 info.portfolio_performance.PortfolioPerformance.appdata.xml /app/share/metainfo/info.portfolio_performance.PortfolioPerformance.appdata.xml",
         "install -Dm 644 info.portfolio_performance.PortfolioPerformance.desktop /app/share/applications/info.portfolio_performance.PortfolioPerformance.desktop",
+        "sed -rie \"s|(osgi.instance.area.default=).*\\$|\\\\1@user.home/.var/app/${FLATPAK_ID}/config/workspace|\" configuration/config.ini",
         "mv * /app/jre/bin/"
       ],
       "sources": [


### PR DESCRIPTION
This patch changes the default location of the configuration file to be inside `~/.var/app/${FLATPAK_ID}/config`, as required by Flatpak to avoid sharing configuration with non-Flatpak installations (see commit message for references).

It also changes the name of the app to "Portfolio Performance" (with a space) as in the UI and website. Finally, it adds the "Finance" and "Java" categories to the .desktop file and the URL to submit translations.